### PR TITLE
Update README.md and configure.ac for build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ It is known to support these printers:
 * Brother DCP-7055
 * Brother DCP-7065DN
 
+Build requirements
+------------------
+Besides a working build environment (i.e. `gcc` or compatible compiler) you will need the header files for libcupsimage2 (especially `raster.h`), as well as the corresponding general build files for CUPS. On Ubuntu and Debian, and their derivatives, these are contained in the following packages and their respective dependencies:
+
+* `libcups2-dev`
+* `libcupsimage2-dev`
+
 Copyright
 ---------
 

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_SUBST(CUPS_LIBS)
 AC_SUBST(CUPS_SERVERBIN)
 AC_SUBST(CUPS_DATADIR)
 AC_CHECK_HEADER("cups/raster.h",,
-	[AC_MSG_ERROR(["raster.h" header file not found. Please install the CUPS image (libcupsimage) development package).])])
+	[AC_MSG_ERROR(["<cups/raster.h>" header file not found. Please install the CUPS image (libcupsimage) development package).])])
 
 dnl 'cups-config --libs' lists a lot of libs we don't need/want,
 dnl try to figure out whether the linker knows about --as-needed.

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_SUBST(CUPS_LIBS)
 AC_SUBST(CUPS_SERVERBIN)
 AC_SUBST(CUPS_DATADIR)
 AC_CHECK_HEADER("cups/raster.h",,
-	[AC_MSG_ERROR(["<cups/raster.h>" header file not found. Please install the CUPS image (libcupsimage) development package).])])
+	[AC_MSG_ERROR(["<cups/raster.h>" header file not found. Please install the CUPS image (libcupsimage2) development package).])])
 
 dnl 'cups-config --libs' lists a lot of libs we don't need/want,
 dnl try to figure out whether the linker knows about --as-needed.

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,8 @@ AC_SUBST(CUPS_CFLAGS)
 AC_SUBST(CUPS_LIBS)
 AC_SUBST(CUPS_SERVERBIN)
 AC_SUBST(CUPS_DATADIR)
+AC_CHECK_HEADER("cups/raster.h",,
+	[AC_MSG_ERROR(["raster.h" header file not found. Please install the CUPS image (libcupsimage) development package).])])
 
 dnl 'cups-config --libs' lists a lot of libs we don't need/want,
 dnl try to figure out whether the linker knows about --as-needed.


### PR DESCRIPTION
Installing "libcups2-dev"  or the respective packages on other Linux variants is not sufficient for a successful build. It lacks `raster.h`. However, neither `autogen.sh` nor `configure` check for `raster.h`, and running `make` will fail, even when the basic CUPS development packages are installer.

I add information about build requirements and specific instructions for Ubuntu and Debian in the Readme and also add a check in the `configure.ac` script for `<cups/raster.h>`.
