### PR TITLE
Add DCP-7040

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ don't work, this one might help.
 It is known to support these printers:
 
 * Brother DCP-7030
+* Brother DCP-7040 (using DCP-7030 entry)
 * Brother DCP-7055
 * Brother DCP-7065DN
 


### PR DESCRIPTION
The entry for DCP-7030 brought to CUPS by brlaser can also make the DCP-7040 working.

I use the package printer-driver-brlaser in Debian Jessie and it works like a charm. Thanks for your work, it allows me to finally get rid of the rotten Brother's x86 packages!
