### PR TITLE
Add missing #include <string>

### DIFF
--- a/src/brdecode.cc
+++ b/src/brdecode.cc
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <exception>
 #include <vector>
+#include <string>
 
 namespace {
 


### PR DESCRIPTION
Without this, it fails to build on newer versions of gcc.
