### PR TITLE
Allow the user to define cups config variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,26 +54,37 @@ find_program(CUPS_CONFIG NAMES cups-config)
 if(NOT CUPS_CONFIG)
   message(FATAL_ERROR "cups-config command not found. Are the CUPS development packages installed?")
 endif()
-execute_process(
-  COMMAND "${CUPS_CONFIG}" --datadir
-  OUTPUT_VARIABLE CUPS_DATA_DIR
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(
-  COMMAND "${CUPS_CONFIG}" --serverbin
-  OUTPUT_VARIABLE CUPS_SERVER_BIN
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(
-  COMMAND "${CUPS_CONFIG}" --cflags
-  OUTPUT_VARIABLE CUPS_CFLAGS
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(
-  COMMAND "${CUPS_CONFIG}" --ldflags
-  OUTPUT_VARIABLE CUPS_LDFLAGS
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(
-  COMMAND "${CUPS_CONFIG}" --image --libs
-  OUTPUT_VARIABLE CUPS_LIBS
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(NOT CUPS_DATA_DIR)
+  execute_process(
+    COMMAND "${CUPS_CONFIG}" --datadir
+    OUTPUT_VARIABLE CUPS_DATA_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+if(NOT CUPS_SERVER_BIN)
+  execute_process(
+    COMMAND "${CUPS_CONFIG}" --serverbin
+    OUTPUT_VARIABLE CUPS_SERVER_BIN
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+if(NOT CUPS_CFLAGS)
+  execute_process(
+    COMMAND "${CUPS_CONFIG}" --cflags
+    OUTPUT_VARIABLE CUPS_CFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+if(NOT CUPS_LDFLAGS)
+  execute_process(
+    COMMAND "${CUPS_CONFIG}" --ldflags
+    OUTPUT_VARIABLE CUPS_LDFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+if(NOT CUPS_LIBS)
+  execute_process(
+    COMMAND "${CUPS_CONFIG}" --image --libs
+    OUTPUT_VARIABLE CUPS_LIBS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
 cmake_push_check_state()
 set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${CUPS_CFLAGS}")

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Installation
 ------------
 
 Some operating systems already ship this driver. This is the case for
-at least Debian, Ubuntu, Raspbian, openSUSE and Arch Linux. Look for a
-package named `printer-driver-brlaser`.
+at least Debian, Ubuntu, Raspbian, openSUSE, NixOS and Arch Linux.
+Look for a package named `printer-driver-brlaser`.
 
 You'll also need Ghostscript, in case that's not installed
 automatically.


### PR DESCRIPTION
This is needed when the paths reported by cups-config are read-only.
As is the case in the NixOS distribution.