### PR TITLE
Fix print problems with HL-L2320D and others

### DIFF
--- a/src/block.h
+++ b/src/block.h
@@ -59,7 +59,7 @@ class block {
 
  private:
   static const unsigned max_block_size_ = 16350;
-  static const unsigned max_lines_per_block_ = 64;
+  static const unsigned max_lines_per_block_ = 32;
 
   std::vector<std::vector<uint8_t>> lines_;
   int line_bytes_;

--- a/test/test_block.cc
+++ b/test/test_block.cc
@@ -40,7 +40,7 @@ const lest::test specification[] = {
   "A block can contain 64 lines",
   [] {
     block b;
-    for (int i = 0; i < 64; ++i) {
+    for (int i = 0; i < 32; ++i) {
       EXPECT(b.line_fits(1));
       b.add_line(vec(1));
     }


### PR DESCRIPTION
- reduce max_lines_per_block from 64 to 32 in block.h, which seems
to improve print success rate

Although I have not gotten a response on #52, it seems like multiple people have confirmed that this helps improve print success rate so I am submitting this PR. As stated in the original issue, I only played around with this variable because it seemed to have helped with print issues in the past although I have not looked into the code enough to determine potential side effects. However, I have tested this for 4 months and it seems like others have also been able to fix their print issues with this fix.  