### PR TITLE
Add Brother DCP-L2520DW

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This driver has been reported to work with these printers:
 * Brother DCP-7080
 * Brother DCP-L2500D series
 * Brother DCP-L2520D series
+* Brother DCP-L2520DW series
 * Brother DCP-L2540DW series
 * Brother HL-1110 series
 * Brother HL-1200 series

--- a/brlaser.drv.in
+++ b/brlaser.drv.in
@@ -174,6 +174,14 @@ Option "brlaserEconomode/Toner save mode" Boolean AnySetup 10
 }
 
 {
+  ModelName "DCP-L2520DW"
+  Attribute "NickName" "" "Brother DCP-L2520DW series, $USING"
+  Attribute "1284DeviceID" "" "MFG:Brother;CMD:PJL,HBP;MDL:DCP-L2520DW series;CLS:PRINTER;CID:Brother Laser Type1;"
+  Duplex rotated
+  PCFileName "brl2520dw.ppd"
+}
+
+{
   ModelName "DCP-L2540DW"
   Attribute "NickName" "" "Brother DCP-L2540DW series, $USING"
   Attribute "1284DeviceID" "" "MFG:Brother;CMD:PJL,HBP;MDL:DCP-L2540DW series;CLS:PRINTER;CID:Brother Laser Type1;"


### PR DESCRIPTION
The output of "sudo lpinfo --include-schemes usb -l -v":

Device: uri = dnssd://Brother%20DCP-L2520DW%20series._ipp._tcp.local/?uuid=e3248000-80ce-11db-8000-7429afa0f9d5
        class = network
        info = Brother DCP-L2520DW series
        make-and-model = Brother DCP-L2520DW series
        device-id = MFG:Brother;MDL:DCP-L2520DW series;CMD:PJL,HBP,URF;
        location = 

The duplex printing works as well.