### PR TITLE
Support for long-edge / short-edge duplexing

### DIFF
--- a/src/job.cc
+++ b/src/job.cc
@@ -73,14 +73,14 @@ void job::write_page_header() {
           page_params_.papersize.c_str());
   fprintf(out_, "@PJL SET PAGEPROTECT = AUTO\n");
   fprintf(out_, "@PJL SET ORIENTATION = PORTRAIT\n");
+  fprintf(out_, "@PJL SET DUPLEX = %s\n",
+          page_params_.duplex ? "ON" : "OFF");
+  fprintf(out_, "@PJL SET BINDING = %s\n",
+          page_params_.tumble ? "SHORTEDGE" : "LONGEDGE");
   fprintf(out_, "@PJL ENTER LANGUAGE = PCL\n");
 
   fputs("\033E", out_);
   fprintf(out_, "\033&l%dX", std::max(1, page_params_.num_copies));
-
-  if (page_params_.duplex) {
-    fputs("\033&l2S", out_);
-  }
 }
 
 void job::encode_page(const page_params &page_params,

--- a/src/job.cc
+++ b/src/job.cc
@@ -77,10 +77,11 @@ void job::write_page_header() {
           page_params_.duplex ? "ON" : "OFF");
   fprintf(out_, "@PJL SET BINDING = %s\n",
           page_params_.tumble ? "SHORTEDGE" : "LONGEDGE");
+  fprintf(out_, "@PJL SET COPIES = %d\n",
+          std::max(1, page_params_.num_copies));
   fprintf(out_, "@PJL ENTER LANGUAGE = PCL\n");
 
   fputs("\033E", out_);
-  fprintf(out_, "\033&l%dX", std::max(1, page_params_.num_copies));
 }
 
 void job::encode_page(const page_params &page_params,

--- a/src/job.h
+++ b/src/job.h
@@ -27,6 +27,7 @@ struct page_params {
   int num_copies;
   int resolution;
   bool duplex;
+  bool tumble;
   bool economode;
   std::string sourcetray;
   std::string mediatype;
@@ -36,6 +37,7 @@ struct page_params {
     return num_copies == o.num_copies
       && resolution == o.resolution
       && duplex == o.duplex
+      && tumble == o.tumble
       && economode == o.economode
       && sourcetray == o.sourcetray
       && mediatype == o.mediatype

--- a/src/main.cc
+++ b/src/main.cc
@@ -111,6 +111,7 @@ page_params build_page_params(const cups_page_header2_t &header) {
   p.economode = header.cupsInteger[10];
   p.mediatype = header.MediaType;
   p.duplex = header.Duplex;
+  p.tumble = header.Tumble;
 
   if (header.MediaPosition < sources.size())
     p.sourcetray = sources[header.MediaPosition];


### PR DESCRIPTION
The `Tumble` option is already gathered from CUPS, but was not being sent to the printer. (`Tumble` = true corresponds to short-edge duplexing, and `Tumble` = false means long-edge duplexing.) Replace the cryptic PCL short-edge duplexing
command with the PJL commands `SET DUPLEX = ON / OFF` and `SET BINDING = LONGEDGE / SHORTEDGE`.

Tested on an HL-L2300D.

![tumble](https://user-images.githubusercontent.com/134711/120222067-63396000-c20d-11eb-98de-4017809548ef.jpg)