### PR TITLE
Add support for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - name: Add repository
         run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - uses: actions/checkout@v2
       - name: Configure
         run: cmake .
       - name: Make
@@ -25,6 +26,7 @@ jobs:
       matrix:
         compiler: [ clang++, gcc++ ]
     steps:
+      - uses: actions/checkout@v2
       - name: Configure
         run: cmake .
       - name: Make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: build
+on: [ push, pull_request ]
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ clang++, gcc++, gcc-9++, gcc-10++ ]
+    steps:
+      - name: Add repository
+        run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - name: Configure
+        run: cmake .
+      - name: Make
+        run: make
+        env:
+          CXX: {{ matrix.compiler }}
+      - name: Run tests
+        run: make check
+  macos:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ clang++, gcc++ ]
+    steps:
+      - name: Configure
+        run: cmake .
+      - name: Make
+        run: make
+        env:
+          CXX: {{ matrix.compiler }}
+      - name: Run tests
+        run: make check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Add repository
         run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+      - name: Install packages
+        run: sudo apt install libcups2-dev
       - uses: actions/checkout@v2
       - name: Configure
         run: cmake .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Make
         run: make
         env:
-          CXX: {{ matrix.compiler }}
+          CXX: ${{ matrix.compiler }}
       - name: Run tests
         run: make check
   macos:
@@ -30,6 +30,6 @@ jobs:
       - name: Make
         run: make
         env:
-          CXX: {{ matrix.compiler }}
+          CXX: ${{ matrix.compiler }}
       - name: Run tests
         run: make check


### PR DESCRIPTION
With this pull request, new pull requests will automatically compile and run the test suite on Ubuntu and macOS. (I suggest merging this before other pull requests so that they can benefit from it.)

Example output: https://github.com/evanmiller/brlaser/actions/runs/893966431