### PR TITLE
Fix MFC-7460DN PPD file name

### DIFF
--- a/brlaser.drv.in
+++ b/brlaser.drv.in
@@ -332,7 +332,7 @@ Option "brlaserEconomode/Toner save mode" Boolean AnySetup 10
   Attribute "NickName" "" "Brother MFC-7460DN, $USING"
   Attribute "1284DeviceID" "" "MFG:Brother;CMD:PJL,HBP;MDL:MFC-7460DN;CLS:PRINTER;CID:Brother Laser Type1;"
   Duplex rotated
-  PCFileName "br7365dn.ppd"
+  PCFileName "br7460dn.ppd"
 }
 
 {


### PR DESCRIPTION
The old PCFileName for the MFC-7460DN (`br7365dn.ppd`) collided with the PCFileName of the MFC-7365DN. (the MFC-7460DN was added in commit https://github.com/pdewacht/brlaser/commit/eae5f9ba98d48901638fc226777825805d734ade)