### PR TITLE
explicitly disable duplex in PCL

### DIFF
--- a/src/job.cc
+++ b/src/job.cc
@@ -80,6 +80,8 @@ void job::write_page_header() {
 
   if (page_params_.duplex) {
     fputs("\033&l2S", out_);
+  } else {
+    fputs("\033&l0S", out_);
   }
 }
 


### PR DESCRIPTION
This seems to be required for the HL-L2350DW, and matches the behaviour of the official driver.

Without this, if duplex is disabled then the printer still duplexes, but every other page is garbled.

I haven't tested this on any other printers. I think this should be safe (it's a standard PCL code), but it might be worth testing against other printers.

I'm using @QORTEC's master branch, but that shouldn't make any difference as the only changes are printer definitions.