### PR TITLE
explicitly disable duplex in PCL

### DIFF
--- a/src/job.cc
+++ b/src/job.cc
@@ -80,6 +80,8 @@ void job::write_page_header() {
 
   if (page_params_.duplex) {
     fputs("\033&l2S", out_);
+  } else {
+    fputs("\033&l0S", out_);
   }
 }
 


### PR DESCRIPTION
this seems to be required for the HL-L2350DW, and matches the behaviour of the official driver

without this, if duplex is disabled then the printer still duplexes, but every other page is garbled