### PR TITLE
Updated Code; Duplex, Simplex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 project(brlaser CXX)
 set(BRLASER_VERSION "6")
 

--- a/brlaser.drv.in
+++ b/brlaser.drv.in
@@ -78,6 +78,20 @@ Option "brlaserEconomode/Toner save mode" Boolean AnySetup 10
   *Choice False/Off "<</cupsInteger10 0>>setpagedevice"
   Choice True/On "<</cupsInteger10 1>>setpagedevice"
 
+Option "brlaserDensityAdjust/Toner Density" PickOne AnySetup 10
+  Choice "94/-6 (lighter)" "<</cupsInteger11 94>>setpagedevice"
+  Choice "95/-5 (lighter)" "<</cupsInteger11 95>>setpagedevice"
+  Choice "96/-4 (lighter)" "<</cupsInteger11 96>>setpagedevice"
+  Choice "97/-3 (lighter)" "<</cupsInteger11 97>>setpagedevice"
+  Choice "98/-2 (lighter)" "<</cupsInteger11 98>>setpagedevice"
+  Choice "99/-1 (lighter)" "<</cupsInteger11 99>>setpagedevice"
+  *Choice "100/0 (default)" "<</cupsInteger11 100>>setpagedevice"
+  Choice "101/+1 (darker)" "<</cupsInteger11 101>>setpagedevice"
+  Choice "102/+2 (darker)" "<</cupsInteger11 102>>setpagedevice"
+  Choice "103/+3 (darker)" "<</cupsInteger11 103>>setpagedevice"
+  Choice "104/+4 (darker)" "<</cupsInteger11 104>>setpagedevice"
+  Choice "105/+5 (darker)" "<</cupsInteger11 105>>setpagedevice"
+  Choice "106/+6 (darker)" "<</cupsInteger11 106>>setpagedevice"
 
 {
   ModelName "DCP-1510"

--- a/brlaser.drv.in
+++ b/brlaser.drv.in
@@ -38,8 +38,15 @@ Filter application/vnd.cups-raster 33 rastertobrlaser
 // The 300dpi mode is reportedly not supported on all printers, so
 // it's listed in individual printer blocks where we believe it works.
 // Resolution k 1 0 0 0 "300dpi/300 DPI"
-*Resolution k 1 0 0 0 "600dpi/600 DPI"
-Resolution k 1 0 0 0 "1200dpi/1200HQ"
+// *Resolution k 1 0 0 0 "600dpi/600 DPI"
+// Resolution k 1 0 0 0 "1200dpi/1200 DPI"
+
+Option Resolution PickOne AnySetup 10
+  // Choice "300dpi/300 DPI" "<</HWResolution[300 300]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0>>setpagedevice"
+  *Choice "600dpi/600 DPI" "<</HWResolution[600 600]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0>>setpagedevice"
+  Choice "1200dpi/1200 DPI" "<</HWResolution[1200 1200]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0>>setpagedevice"
+  Choice "1200x600dpi/HD1200A" "<</HWResolution[1200 1200]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0/cupsInteger12 2>>setpagedevice"
+  Choice "2400x600dpi/HD1200B" "<</HWResolution[1200 1200]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0/cupsInteger12 1>>setpagedevice"
 
 // Supported page sizes.
 HWMargins 8 8 8 16

--- a/src/job.cc
+++ b/src/job.cc
@@ -80,6 +80,8 @@ void job::write_page_header() {
 
   if (page_params_.duplex) {
     fputs("\033&l2S", out_);
+  } else {
+    fputs("\033&l0S", out_);
   }
 }
 

--- a/src/job.cc
+++ b/src/job.cc
@@ -78,8 +78,10 @@ void job::write_page_header() {
   fputs("\033E", out_);
   fprintf(out_, "\033&l%dX", std::max(1, page_params_.num_copies));
 
-  if (page_params_.duplex) {
+  if (page_params_.duplex && page_params_.tumble) {
     fputs("\033&l2S", out_);
+  } else if (page_params_.duplex) {
+    fputs("\033&l1S", out_);
   } else {
     fputs("\033&l0S", out_);
   }

--- a/src/job.cc
+++ b/src/job.cc
@@ -78,10 +78,8 @@ void job::write_page_header() {
   fputs("\033E", out_);
   fprintf(out_, "\033&l%dX", std::max(1, page_params_.num_copies));
 
-  if (page_params_.duplex && page_params_.tumble) {
+  if (page_params_.duplex || page_params_.tumble) {
     fputs("\033&l2S", out_);
-  } else if (page_params_.duplex) {
-    fputs("\033&l1S", out_);
   } else {
     fputs("\033&l0S", out_);
   }

--- a/src/job.cc
+++ b/src/job.cc
@@ -69,6 +69,8 @@ void job::write_page_header() {
           page_params_.sourcetray.c_str());
   fprintf(out_, "@PJL SET MEDIATYPE = %s\n",
           page_params_.mediatype.c_str());
+  fprintf(out_, "@PJL SET DENSITY=%d\n", page_params_.density_adjust);
+  fprintf(out_, "@PJL SET DEVBIASADJUST=%d\n", page_params_.density_adjust);
   fprintf(out_, "@PJL SET PAPER = %s\n",
           page_params_.papersize.c_str());
   fprintf(out_, "@PJL SET PAGEPROTECT = AUTO\n");

--- a/src/job.h
+++ b/src/job.h
@@ -27,6 +27,7 @@ struct page_params {
   int num_copies;
   int resolution;
   bool duplex;
+  bool tumble;
   bool economode;
   std::string sourcetray;
   std::string mediatype;
@@ -36,6 +37,7 @@ struct page_params {
     return num_copies == o.num_copies
       && resolution == o.resolution
       && duplex == o.duplex
+      && tumble == o.tumble
       && economode == o.economode
       && sourcetray == o.sourcetray
       && mediatype == o.mediatype

--- a/src/job.h
+++ b/src/job.h
@@ -26,6 +26,8 @@
 struct page_params {
   int num_copies;
   int resolution;
+  int page_speed;
+  bool ras1200;
   bool duplex;
   bool tumble;
   bool economode;
@@ -37,6 +39,8 @@ struct page_params {
   bool operator==(const page_params &o) const {
     return num_copies == o.num_copies
       && resolution == o.resolution
+      && page_speed == o.page_speed
+      && ras1200 == o.ras1200
       && duplex == o.duplex
       && tumble == o.tumble
       && economode == o.economode

--- a/src/job.h
+++ b/src/job.h
@@ -29,6 +29,7 @@ struct page_params {
   bool duplex;
   bool tumble;
   bool economode;
+  int density_adjust;
   std::string sourcetray;
   std::string mediatype;
   std::string papersize;
@@ -39,6 +40,7 @@ struct page_params {
       && duplex == o.duplex
       && tumble == o.tumble
       && economode == o.economode
+      && density_adjust == o.density_adjust
       && sourcetray == o.sourcetray
       && mediatype == o.mediatype
       && papersize == o.papersize;

--- a/src/main.cc
+++ b/src/main.cc
@@ -111,6 +111,7 @@ page_params build_page_params(const cups_page_header2_t &header) {
   p.economode = header.cupsInteger[10];
   p.mediatype = header.MediaType;
   p.duplex = header.Duplex;
+  p.tumble = header.Tumble;
 
   if (header.MediaPosition < sources.size())
     p.sourcetray = sources[header.MediaPosition];

--- a/src/main.cc
+++ b/src/main.cc
@@ -109,6 +109,7 @@ page_params build_page_params(const cups_page_header2_t &header) {
   p.num_copies = header.NumCopies;
   p.resolution = header.HWResolution[0];
   p.economode = header.cupsInteger[10];
+  p.density_adjust = (header.cupsInteger[11] - 100);
   p.mediatype = header.MediaType;
   p.duplex = header.Duplex;
   p.tumble = header.Tumble;

--- a/src/main.cc
+++ b/src/main.cc
@@ -108,6 +108,8 @@ page_params build_page_params(const cups_page_header2_t &header) {
   page_params p = { };
   p.num_copies = header.NumCopies;
   p.resolution = header.HWResolution[0];
+  p.page_speed = header.cupsInteger[12];
+  p.ras1200 = (p.resolution == 1200 && p.page_speed == 2);
   p.economode = header.cupsInteger[10];
   p.density_adjust = (header.cupsInteger[11] - 100);
   p.mediatype = header.MediaType;

--- a/test/tempfile.h
+++ b/test/tempfile.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <cstdint>
 #include <vector>
 
 class tempfile {


### PR DESCRIPTION
Duplex, Simplex
-----------------------

The following code explicitly sets the duplex/simplex in PCL.
````c
if (page_params_.duplex || page_params_.tumble) {
    fputs("\033&l2S", out_);
  } else {
    fputs("\033&l0S", out_);
  }
````
``\033&l2S``: This sets the printer to duplex printing with tumble mode.
``\033&l1S``: This sets the printer to duplex printing without tumble mode. (Not Used)
``\033&l0S``: This sets the printer to simplex (single-sided) printing.

pdewacht#169 explicitly sets the printer in simplex mode (``\033&l0S``).
This resolves the issue of printers continuing to duplex when disabled. 

QORTEC/brlaser#2 adds duplex no tumble printing.

Toner Density
-----------------------
Owl-Maintain/brlaser#12 adds toner density adjustment

1200dpi
-----------------------
The following code explicitly sets the 1200dpi mode.
```c
  // brlaser.drv.in
  Option Resolution PickOne AnySetup 10
    // Choice "300dpi/300 DPI" "<</HWResolution[300 300]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0>>setpagedevice"
    *Choice "600dpi/600 DPI" "<</HWResolution[600 600]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0>>setpagedevice"
    Choice "1200dpi/1200 DPI" "<</HWResolution[1200 1200]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0>>setpagedevice"
    Choice "1200x600dpi/HD1200A" "<</HWResolution[1200 1200]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0/cupsInteger12 2>>setpagedevice"
    Choice "2400x600dpi/HD1200B" "<</HWResolution[1200 1200]/cupsColorSpace 3/cupsBitsPerColor 1/cupsRowCount 0/cupsRowFeed 0/cupsRowStep 0/cupsInteger12 1>>setpagedevice"

  // main.cc
  p.page_speed = header.cupsInteger[12];
  p.ras1200 = (p.resolution == 1200 && p.page_speed == 2);

  // job.cc
  if (page_params_.ras1200) {
    fprintf(out_, "@PJL SET RAS1200MODE = TRUE\n");
    fprintf(out_, "@PJL SET RESOLUTION = 600\n");
  } else {
    fprintf(out_, "@PJL SET RAS1200MODE = FALSE\n");
    fprintf(out_, "@PJL SET RESOLUTION = %d\n",
            page_params_.resolution);
    if (page_params_.resolution == 1200) {
      fprintf(out_, "@PJL SET PAPERFEEDSPEED = %s\n",
              page_params_.page_speed ? "FULL" : "HALF");
    }

  // PCL Section
  fprintf(out_, "\033&u%dD",
          page_params_.resolution);
  fprintf(out_, "\033*t%dR",
          page_params_.ras1200 ? 600 : page_params_.resolution);

```

Brother uses multiple 1200‑dpi modes across its printers:
- 1200dpi – a true 1200 × 1200 resolution
- HQ1200A – simulates 1200 dpi by printing at 1200 × 600
- HQ1200B – simulates 1200 dpi by printing at 2400 × 600

Compiling
---------------

QORTEC/brlaser#3 fixes building on Fedora 38; 
`` error: 'uint8_t' was not declared in this scope``
Resolves , so ``uint8_t`` undeclared issue by explicitly including ``cstdint`` in ``test/tempfile.h``.

Owl-Maintain/brlaser#43 fixes building with CMake 4.0
`Compatibility with CMake < 3.5 has been removed from CMake.`

Related issues
-------------------- 
#75  1200dpi
#154 1200dpi
#210 1200dpi 
#208 1200dip
#218 CMake
#100 Simplex